### PR TITLE
Implement restrictions on the users flusher

### DIFF
--- a/candid/root.did
+++ b/candid/root.did
@@ -44,6 +44,7 @@ type WithIdArg = record { id : nat64; witness : bool };
 type WithWitnessArg = record { witness : bool };
 type Witness = record { certificate : vec nat8; tree : vec nat8 };
 service : {
+  cap_bypass_rate_limit : () -> ();
   get_bucket_for : (WithIdArg) -> (GetBucketResponse) query;
   get_next_canisters : (WithWitnessArg) -> (GetNextCanistersResponse) query;
   get_transaction : (WithIdArg) -> (GetTransactionResponse) query;

--- a/canisters/root/src/context.rs
+++ b/canisters/root/src/context.rs
@@ -1,0 +1,64 @@
+use ic_kit::ic;
+use ic_kit::Principal;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// The general meta information that we store for this root bucket
+/// canister.
+///
+/// This is a singleton struct.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CapContext {
+    /// Principal id of the main cap's router canister.
+    pub cap_canister_id: Principal,
+    /// Principal id of the contract that is writing its history
+    /// to this root bucket.
+    pub contract_id: Principal,
+    /// The principal id of the different canisters or user pid that
+    /// are allowed to write information and insert transactions to
+    /// this root bucket.
+    pub writers: HashSet<Principal>,
+    /// If set to be true, we skip any rate limiting applied to the
+    /// insertions, by default this value should be set to false for
+    /// newly generated buckets and we should only change it to true
+    /// if a request goes thought the governance module from the
+    /// router.
+    ///
+    /// The rate limiting is used to prevent DDoS attack on the router
+    /// canister.
+    pub ignore_rate_limit: bool,
+}
+
+impl CapContext {
+    /// Returns the context used to communicate with Cap.
+    ///
+    /// # Panics
+    ///
+    /// If executed before setting up the context, the default
+    /// set up happens during init.
+    pub fn get() -> &'static CapContext {
+        ic::get_maybe::<CapContext>().unwrap()
+    }
+
+    /// Returns true if the given principal id is allowed to insert
+    /// transactions in this bucket.
+    pub fn is_writer(&self, pid: &Principal) -> bool {
+        if pid == &self.contract_id {
+            return true;
+        }
+
+        if self.writers.contains(pid) {
+            return true;
+        }
+
+        false
+    }
+
+    /// Change the ignore_rate_limit to true to enable bypassing any
+    /// rate limits.
+    pub fn bypass_rate_limit() {
+        let mut data = Self::get().clone();
+        data.ignore_rate_limit = true;
+        ic::store(data);
+    }
+}

--- a/canisters/root/src/users.rs
+++ b/canisters/root/src/users.rs
@@ -1,0 +1,112 @@
+use crate::context::CapContext;
+use ic_kit::ic;
+use ic_kit::Principal;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashSet};
+
+/// Number of new principal ids that once passed, we try to perform
+/// another flush.
+const USERS_FLUSH_THRESHOLD_COUNT: usize = 15;
+/// Time that once passed since the last flush, we perform another
+/// flush.
+const USERS_FLUSH_THRESHOLD_TIME: u64 = 2000;
+/// The minimum time that must be passed since the last flush in
+/// order to perform another flush.
+/// In other words if the last flush is performed less than x-ms
+/// ago we should prevent a new flush.
+/// This ensures that we only perform at most 1 call per each x-ms.
+const USER_FLUSH_MIN_PASSED_TIME: u64 = 1000;
+/// When rate limiting is enabled on the canister limit the number
+/// of unique principal ids that each event can have to this number,
+/// this limit should be disregarded for when [`CapContext::ignore_rate_limit`]
+/// is set to `true`.
+const MAX_PRINCIPALS_PER_EVENT: usize = 7;
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct Users {
+    seen: HashSet<Principal>,
+    to_flush: HashSet<Principal>,
+    last_flush: u64,
+}
+
+impl Users {
+    /// Extract new user principal ids from the event in order to notify
+    /// the root canister so that it can list us as interacted contract
+    /// for the user.
+    #[inline]
+    pub fn insert(&mut self, ctx: &CapContext, principals: BTreeSet<&Principal>) {
+        if !ctx.ignore_rate_limit && principals.len() > MAX_PRINCIPALS_PER_EVENT {
+            panic!(
+                "Number of principals in a single event can not exceed {}",
+                MAX_PRINCIPALS_PER_EVENT
+            );
+        }
+
+        for principal in principals {
+            if self.seen.insert(*principal) {
+                self.to_flush.insert(*principal);
+            }
+        }
+    }
+
+    /// Try to write the data to cap router if the flush conditions are met, otherwise
+    /// it's just a no-op.
+    #[inline]
+    pub fn trigger_flush(&mut self, ctx: &'static CapContext) {
+        if self.to_flush.is_empty() {
+            return;
+        }
+
+        // div by 1e6 to convert from nanoseconds to milliseconds.
+        let time = ic::time() / 1_000_000;
+
+        // I'm not sure if you can travel back in time on IC when dealing with time
+        // in ms, so it's better than be safe than sorry and use saturating_sub
+        // here.
+        let time_passed_since_last_flush = time.saturating_sub(self.last_flush);
+
+        // This ensures that we perform at most 1 request to the router canister
+        // second.
+        if time_passed_since_last_flush < USER_FLUSH_MIN_PASSED_TIME {
+            return;
+        }
+
+        if self.to_flush.len() >= USERS_FLUSH_THRESHOLD_COUNT
+            || time_passed_since_last_flush >= USERS_FLUSH_THRESHOLD_TIME
+        {
+            let principals = self.to_flush.drain().collect::<Vec<_>>();
+            ic_cdk::block_on(perform_flush(ctx, principals));
+            self.last_flush = time;
+        }
+    }
+}
+
+/// Tries to write the new unique principal ids that have interacted with this
+/// token contract to Cap's router, we do this in a fail tolerant way.
+async fn perform_flush(ctx: &'static CapContext, principals: Vec<Principal>) {
+    let cap_id = ctx.cap_canister_id;
+    let contract_id = &ctx.contract_id;
+
+    // Retry 3 times, if failed after all retries try to insert the
+    // transactions back to Users structure.
+    for _ in 0..3 {
+        let args = (contract_id, &principals);
+        if ic::call::<(&Principal, &Vec<Principal>), (), &str>(cap_id, "insert_new_users", args)
+            .await
+            .is_ok()
+        {
+            return;
+        }
+    }
+
+    // This case is really unlikely to happen in reality, the only possibilities
+    // that I reckon this case being met is for when there is a network mis-
+    // configuration on the current subnet, so that it can not reach the
+    // subnet in which Cap's router canister is located, so it's worth to
+    // take that kind of possibility into account to be more fail tolerant.
+    // In this case there is nothing we can really do that not losing the
+    // data so we can insert it once the subnet issue is resolved.
+
+    let users = ic::get_mut::<Users>();
+    users.to_flush.extend(principals.into_iter());
+}

--- a/common/src/bucket.rs
+++ b/common/src/bucket.rs
@@ -95,14 +95,14 @@ impl Bucket {
     }
 
     /// Try to insert an event into the bucket.
-    pub fn insert(&mut self, contract: &Principal, event: Event) -> u64 {
+    pub fn insert(&mut self, contract_id: &Principal, event: Event) -> u64 {
         let local_index = self.events.len() as u32;
         let hash = event.hash();
         let event: NonNull<Event> = Box::leak(Box::new(event)).into();
         let eve = unsafe { event.as_ref() };
 
         // Update the indexers for the transaction.
-        self.contract_indexer.insert(contract, event, &hash);
+        self.contract_indexer.insert(contract_id, event, &hash);
         for user in eve.extract_principal_ids() {
             self.user_indexer.insert(user, event, &hash);
         }


### PR DESCRIPTION
This PR should be merged after a full round of testing.

This PR adds enhancements to the cap's root bucket canister, to limit its outgoing requests to cap's router canister in order to increase security. It also lays the foundation for rate limiting root buckets by default. No more work has been done there on that front since it should be its separate PR.