### PR TITLE
Implement post_upgrade & add contract_id to root bucket

### DIFF
--- a/candid/root.did
+++ b/candid/root.did
@@ -44,6 +44,7 @@ type WithIdArg = record { id : nat64; witness : bool };
 type WithWitnessArg = record { witness : bool };
 type Witness = record { certificate : vec nat8; tree : vec nat8 };
 service : {
+  contract_id : () -> (principal) query;
   get_bucket_for : (WithIdArg) -> (GetBucketResponse) query;
   get_next_canisters : (WithWitnessArg) -> (GetNextCanistersResponse) query;
   get_transaction : (WithIdArg) -> (GetTransactionResponse) query;

--- a/candid/router.did
+++ b/candid/router.did
@@ -28,4 +28,5 @@ service : {
     ) query;
   insert_new_users : (principal, vec principal) -> ();
   install_bucket_code : (principal) -> ();
+  trigger_upgrade : () -> ();
 }

--- a/canisters/root/src/lib.rs
+++ b/canisters/root/src/lib.rs
@@ -215,6 +215,12 @@ fn size() -> u64 {
     ic::get::<Data>().bucket.size()
 }
 
+#[query]
+#[candid_method(query)]
+fn contract_id() -> Principal {
+    ic::get::<Data>().contract
+}
+
 #[update]
 #[candid_method(update)]
 fn insert(event: IndefiniteEvent) -> TransactionId {

--- a/canisters/root/src/upgrade.rs
+++ b/canisters/root/src/upgrade.rs
@@ -86,6 +86,8 @@ mod tests {
         }
 
         let serialized = serde_cbor::to_vec(data).expect("Failed to serialize.");
-        let _: DataDe = serde_cbor::from_slice(&serialized).expect("Failed to deserialize.");
+        let actual: DataDe = serde_cbor::from_slice(&serialized).expect("Failed to deserialize.");
+
+        assert_eq!(actual.bucket.len(), 100);
     }
 }

--- a/canisters/root/src/upgrade.rs
+++ b/canisters/root/src/upgrade.rs
@@ -1,7 +1,26 @@
 use crate::Data;
 use ic_cdk::api::stable::{StableReader, StableWriter};
-use ic_kit::ic;
-use ic_kit::macros::{pre_upgrade, post_upgrade};
+use ic_history_common::bucket_lookup_table::BucketLookupTable;
+use ic_history_common::canister_list::CanisterList;
+use ic_history_common::transaction::Event;
+use ic_history_common::{Bucket, TokenContractId};
+use ic_kit::macros::{post_upgrade, pre_upgrade};
+use ic_kit::{ic, Principal};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+
+#[derive(Deserialize)]
+struct DataDe {
+    bucket: Vec<Event>,
+    buckets: BucketLookupTable,
+    next_canisters: CanisterList,
+    /// List of all the users in this token contract.
+    users: BTreeSet<Principal>,
+    cap_id: Principal,
+    contract: TokenContractId,
+    writers: BTreeSet<TokenContractId>,
+    allow_migration: bool,
+}
 
 #[pre_upgrade]
 fn pre_upgrade() {
@@ -13,6 +32,23 @@ fn pre_upgrade() {
 #[post_upgrade]
 fn post_upgrade() {
     let reader = StableReader::default();
-    let data = serde_cbor::from_reader(reader).expect("Failed to deserialize");
-    ic::store::<Data>(data);
+    let data: DataDe = serde_cbor::from_reader(reader).expect("Failed to deserialize");
+
+    let contract = data.contract;
+
+    let mut bucket = Bucket::new(0);
+    for event in data.bucket {
+        bucket.insert(&contract, event);
+    }
+
+    ic::store(Data {
+        bucket,
+        buckets: data.buckets,
+        next_canisters: data.next_canisters,
+        users: data.users,
+        cap_id: data.cap_id,
+        contract,
+        writers: data.writers,
+        allow_migration: data.allow_migration,
+    })
 }

--- a/canisters/root/src/upgrade.rs
+++ b/canisters/root/src/upgrade.rs
@@ -1,11 +1,18 @@
 use crate::Data;
-use ic_cdk::api::stable::StableWriter;
+use ic_cdk::api::stable::{StableReader, StableWriter};
 use ic_kit::ic;
-use ic_kit::macros::pre_upgrade;
+use ic_kit::macros::{pre_upgrade, post_upgrade};
 
 #[pre_upgrade]
 fn pre_upgrade() {
     let data = ic::get::<Data>();
     let writer = StableWriter::default();
     serde_cbor::to_writer(writer, &data).expect("Failed to serialize data.");
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    let reader = StableReader::default();
+    let data = serde_cbor::from_reader(reader).expect("Failed to deserialize");
+    ic::store::<Data>(data);
 }

--- a/canisters/router/src/lib.rs
+++ b/canisters/router/src/lib.rs
@@ -5,7 +5,7 @@ use ic_history_common::canister_map::CanisterMap;
 use ic_history_common::user_canisters::UserCanisters;
 use ic_kit::candid::{candid_method, export_service};
 use ic_kit::ic;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 // It's ok.
 use ic_cdk::export::Principal;
@@ -26,7 +26,7 @@ mod upgrade;
 ///     /   \
 ///   / \    2
 ///  0   1
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Data {
     /// Map: TokenContractId -> RootBucketId
     root_buckets: CanisterMap,

--- a/canisters/router/src/lib.rs
+++ b/canisters/router/src/lib.rs
@@ -29,11 +29,11 @@ mod upgrade;
 #[derive(Serialize, Deserialize)]
 pub struct Data {
     /// Map: TokenContractId -> RootBucketId
-    root_buckets: CanisterMap,
+    pub root_buckets: CanisterMap,
     /// Map each user to RootBucketId
-    user_canisters: UserCanisters,
+    pub user_canisters: UserCanisters,
     /// List of the index canisters.
-    index_canisters: CanisterList,
+    pub index_canisters: CanisterList,
 }
 
 impl Default for Data {

--- a/canisters/router/src/upgrade.rs
+++ b/canisters/router/src/upgrade.rs
@@ -102,7 +102,6 @@ mod tests {
 
         MockContext::new().with_id(p(17)).inject();
 
-
         let mut data = Data::default();
         data.root_buckets.insert(contract_1, rb_1);
         data.root_buckets.insert(contract_2, rb_2);

--- a/canisters/router/src/upgrade.rs
+++ b/canisters/router/src/upgrade.rs
@@ -1,7 +1,13 @@
-use crate::Data;
+use crate::{get_user_root_buckets, Data};
 use ic_cdk::api::stable::{StableReader, StableWriter};
+use ic_history_common::{GetUserRootBucketsArg, RootBucketId};
+use ic_kit::candid::{candid_method, encode_args};
 use ic_kit::ic;
-use ic_kit::macros::{post_upgrade, pre_upgrade};
+use ic_kit::macros::{post_upgrade, pre_upgrade, update};
+use ic_kit::Principal;
+
+#[derive(Default)]
+struct RootBucketsToUpgrade(Vec<RootBucketId>);
 
 #[pre_upgrade]
 fn pre_upgrade() {
@@ -15,4 +21,58 @@ fn post_upgrade() {
     let reader = StableReader::default();
     let data = serde_cbor::from_reader(reader).expect("Failed to deserialize");
     ic::store::<Data>(data);
+
+    let root_buckets = get_user_root_buckets(GetUserRootBucketsArg {
+        user: Principal::management_canister(),
+        witness: false,
+    })
+    .contracts;
+
+    ic::store(RootBucketsToUpgrade(root_buckets.to_vec()));
+}
+
+#[update]
+#[candid_method(update)]
+fn trigger_upgrade() {
+    let canisters = ic::get_mut::<RootBucketsToUpgrade>();
+
+    if canisters.0.is_empty() {
+        return;
+    }
+
+    for _ in 0..16 {
+        if let Some(canister_id) = canisters.0.pop() {
+            ic_cdk::block_on(upgrade_root_bucket(canister_id));
+        } else {
+            break;
+        }
+    }
+}
+
+async fn upgrade_root_bucket(canister_id: Principal) {
+    use crate::installer::{InstallCodeArgumentBorrowed, WASM};
+    use ic_kit::interfaces::management::InstallMode;
+
+    let arg = encode_args(()).expect("Failed to serialize upgrade arg");
+    let install_config = InstallCodeArgumentBorrowed {
+        mode: InstallMode::Upgrade,
+        canister_id,
+        wasm_module: WASM,
+        arg,
+    };
+
+    if ic::call::<_, (), _>(
+        Principal::management_canister(),
+        "install_code",
+        (install_config,),
+    )
+    .await
+    .is_err()
+    {
+        // Retry.
+        let canisters = ic::get_mut::<RootBucketsToUpgrade>();
+        canisters.0.push(canister_id);
+    }
+
+    trigger_upgrade();
 }

--- a/canisters/router/src/upgrade.rs
+++ b/canisters/router/src/upgrade.rs
@@ -61,7 +61,10 @@ async fn upgrade_root_bucket(canister_id: Principal) {
         arg,
     };
 
+    // Mr. Fox
+    //            /\    /\
     if ic::call::<_, (), _>(
+        //        \_______/
         Principal::management_canister(),
         "install_code",
         (install_config,),
@@ -75,4 +78,45 @@ async fn upgrade_root_bucket(canister_id: Principal) {
     }
 
     trigger_upgrade();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_kit::MockContext;
+
+    const fn p(id: u8) -> Principal {
+        Principal::from_slice(&[id, 0x00])
+    }
+
+    #[test]
+    fn test_p() {
+        let principal = p(67);
+        let serialized = serde_cbor::to_vec(&principal).expect("Failed to serialize.");
+        let actual: Principal =
+            serde_cbor::from_slice(&serialized).expect("Failed to deserialize.");
+        assert_eq!(principal, actual);
+    }
+
+    #[test]
+    fn test() {
+        let contract_1 = p(0);
+        let rb_1 = p(1);
+        let contract_2 = p(2);
+        let rb_2 = p(3);
+        let alice = p(4);
+        let bob = p(5);
+
+        MockContext::new().with_id(p(17)).inject();
+
+        let mut data = Data::default();
+        data.root_buckets.insert(contract_1, rb_1);
+        data.root_buckets.insert(contract_2, rb_2);
+        data.user_canisters.insert(alice, rb_1);
+        data.user_canisters.insert(alice, rb_2);
+        data.user_canisters.insert(bob, rb_2);
+
+        let serialized = serde_cbor::to_vec(&data).expect("Failed to serialize.");
+        let actual: Data = serde_cbor::from_slice(&serialized).expect("Failed to deserialize.");
+    }
 }

--- a/canisters/router/src/upgrade.rs
+++ b/canisters/router/src/upgrade.rs
@@ -83,19 +83,12 @@ async fn upgrade_root_bucket(canister_id: Principal) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ic_certified_map::AsHashTree;
     use ic_kit::MockContext;
 
+    // TODO(qti3e) Move this to ic-kit.
     const fn p(id: u8) -> Principal {
         Principal::from_slice(&[id, 0x00])
-    }
-
-    #[test]
-    fn test_p() {
-        let principal = p(67);
-        let serialized = serde_cbor::to_vec(&principal).expect("Failed to serialize.");
-        let actual: Principal =
-            serde_cbor::from_slice(&serialized).expect("Failed to deserialize.");
-        assert_eq!(principal, actual);
     }
 
     #[test]
@@ -109,6 +102,7 @@ mod tests {
 
         MockContext::new().with_id(p(17)).inject();
 
+
         let mut data = Data::default();
         data.root_buckets.insert(contract_1, rb_1);
         data.root_buckets.insert(contract_2, rb_2);
@@ -118,5 +112,18 @@ mod tests {
 
         let serialized = serde_cbor::to_vec(&data).expect("Failed to serialize.");
         let actual: Data = serde_cbor::from_slice(&serialized).expect("Failed to deserialize.");
+
+        assert_eq!(
+            actual.user_canisters.root_hash(),
+            data.user_canisters.root_hash()
+        );
+        assert_eq!(
+            actual.root_buckets.root_hash(),
+            data.root_buckets.root_hash()
+        );
+        assert_eq!(
+            actual.index_canisters.root_hash(),
+            data.index_canisters.root_hash()
+        );
     }
 }

--- a/canisters/router/src/upgrade.rs
+++ b/canisters/router/src/upgrade.rs
@@ -1,7 +1,7 @@
 use crate::Data;
 use ic_cdk::api::stable::{StableReader, StableWriter};
 use ic_kit::ic;
-use ic_kit::macros::{pre_upgrade, post_upgrade};
+use ic_kit::macros::{post_upgrade, pre_upgrade};
 
 #[pre_upgrade]
 fn pre_upgrade() {

--- a/canisters/router/src/upgrade.rs
+++ b/canisters/router/src/upgrade.rs
@@ -1,11 +1,18 @@
 use crate::Data;
-use ic_cdk::api::stable::StableWriter;
+use ic_cdk::api::stable::{StableReader, StableWriter};
 use ic_kit::ic;
-use ic_kit::macros::pre_upgrade;
+use ic_kit::macros::{pre_upgrade, post_upgrade};
 
 #[pre_upgrade]
 fn pre_upgrade() {
     let data = ic::get::<Data>();
     let writer = StableWriter::default();
     serde_cbor::to_writer(writer, &data).expect("Failed to serialize data.");
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    let reader = StableReader::default();
+    let data = serde_cbor::from_reader(reader).expect("Failed to deserialize");
+    ic::store::<Data>(data);
 }

--- a/common/src/canister_map.rs
+++ b/common/src/canister_map.rs
@@ -87,7 +87,10 @@ impl<'de> Deserialize<'de> for CanisterMap {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_map(CanisterMapVisitor)
+        println!("Deserializing canister map.");
+        let ret = deserializer.deserialize_map(CanisterMapVisitor).expect("Failed x-0");
+        println!("Deserialized canister map.");
+        Ok(ret)
     }
 }
 

--- a/common/src/canister_map.rs
+++ b/common/src/canister_map.rs
@@ -87,10 +87,7 @@ impl<'de> Deserialize<'de> for CanisterMap {
     where
         D: Deserializer<'de>,
     {
-        println!("Deserializing canister map.");
-        let ret = deserializer.deserialize_map(CanisterMapVisitor).expect("Failed x-0");
-        println!("Deserialized canister map.");
-        Ok(ret)
+        deserializer.deserialize_map(CanisterMapVisitor)
     }
 }
 
@@ -109,7 +106,9 @@ impl<'de> Visitor<'de> for CanisterMapVisitor {
     {
         let mut data = CanisterMap::default();
 
-        while let Some((key, value)) = map.next_entry::<Principal, Principal>()? {
+        while let Some((key, value)) = map.next_entry::<Vec<u8>, Vec<u8>>()? {
+            let key = Principal::from_slice(&key);
+            let value = Principal::from_slice(&value);
             data.insert(key, value);
         }
 


### PR DESCRIPTION
Once we switch to use certified-vars, this custom serialization logic won't be needed anymore, but for now it's okay although I don't really like how it looks atm. 