### PR TITLE
Add delegation to `query.rs`

### DIFF
--- a/sdk/core/src/bucket.rs
+++ b/sdk/core/src/bucket.rs
@@ -13,7 +13,7 @@ use cap_common::{
 /// contract is created using multiple bucket canisters, which are interconnected using a root bucket
 /// and router system. Querying buckets also features pagination.
 #[derive(Copy, Clone)]
-pub struct Bucket(pub(crate) Principal);
+pub struct Bucket(pub Principal);
 
 impl Bucket {
     /// Returns the list of canisters which have different pages of data.

--- a/sdk/core/src/root.rs
+++ b/sdk/core/src/root.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Use [`RootBucket`]'s [`Into<Bucket>`] implementation to use a [`RootBucket`] as a [`Bucket`].
 #[derive(Copy, Clone, Serialize, Deserialize, CandidType)]
-pub struct RootBucket(pub(crate) Principal);
+pub struct RootBucket(pub Principal);
 
 impl RootBucket {
     /// Returns a bucket that be used to query for the given transaction ID.


### PR DESCRIPTION
Uses `while let` to follow a `GetTransactionResponse::Delegate` until it returns an error or returns `GetTransactionResponse::Found`