### PR TITLE
fix: 🐛 support the token contract id as a controller

### DIFF
--- a/canisters/router/src/installer.rs
+++ b/canisters/router/src/installer.rs
@@ -54,7 +54,9 @@ pub async fn install_code(canister_id: Principal, contract_id: Principal, writer
     .await
     .expect("Failed to retrieve canister status");
 
-    if response.settings.controllers.len() > 1 {
+    let controller_count = response.settings.controllers.len();
+    let has_contract_ctrlr = response.settings.controllers.contains(&contract_id);
+    if controller_count > 1 && !(controller_count == 2 && has_contract_ctrlr) {
         panic!("Expected one controller on canister {}", canister_id);
     }
 


### PR DESCRIPTION
## Why?

On the integration of the Cap Motoko Library (PR https://github.com/Psychedelic/cap-motoko-library/pull/2), it was noted a few issues which can be verified by the long discussion here (https://discord.com/channels/837010835423494144/887363387909079062/921435040297140275), you might have to scroll up early on the day to find about more.

While this might not be the appropriate approach, it should expose an issue where the process differs from the Rust library for the same effects on using Cap Service (described at a higher level here https://discord.com/channels/837010835423494144/887363387909079062/921421065849294888):

Bear in mind, that the process might have changed slightly from the time this was originally written down in the Discord channel:

```
Rust
  - Creates router actor
  - declares create_settings paramters
    - sets controller as router id
  - checks if get_token_contract_root_bucket by app id to find root
    - otherwise
      - creates canister with create_settings as arguments and creation cycles
      - the created canister id is used by a router.install_code
  - gets the root id

Motoko
  - creates router actor
  - check if get_token_contract_root_bucket has app id to find root
  - if available, updates main root bucket
    - otherwise
      - creates settings var where controllers is router id
      - add cycles
      - calls ic management create_canister using the settings var for root canister
      - creates router actor, for some reason...
      - calls router install_bucket_code where canister is the created root canister
        - fails at this point here
      - call router get_token_contract_root_bucket
      - gets the root id
```

## How?

The controller verification in the install code handler, takes into account the canister id of the token contract; Thus, excludes it from the verification and fallback to throwing the exception when there's more then one controller, as originally asserted. If questioned, then you are being advised to read the discussion in the Discord channel (will have to scroll up from the point/url shared above) to see the examples and tracing of the issue - bare in mind that this takes a given amount of personal effort, so its easier to follow what was written and shared, as otherwise will take time to get to that point from memory.

## Notes?

⚠️ Important: should be noted that the latest in Cap (https://github.com/Psychedelic/cap) is broken, that is, the Cap Service does not build or deploy locally; while this was not verified against Rust updates, etc, it was noted while working from the branched version we can see here (https://github.com/Psychedelic/cap/tree/fix/cap-motoko-library-integration-amends) branched from `ad3272da7` (https://github.com/Psychedelic/cap/tree/ad3272da7b7669671471f288c4b47e7ffe9a20db).
