### PR TITLE
Shrink unsafe block

### DIFF
--- a/common/src/transaction_list.rs
+++ b/common/src/transaction_list.rs
@@ -300,13 +300,13 @@ impl AsHashTree for TransactionList {
 
 impl Drop for TransactionList {
     fn drop(&mut self) {
-        unsafe {
+        
             for event in &self.events {
-                let as_mut_ref = &mut (*event.as_ptr());
-                ptr::drop_in_place(as_mut_ref);
-                dealloc(event.cast().as_ptr(), Layout::for_value(event.as_ref()));
+                let as_mut_ref = unsafe { &mut (*event.as_ptr()) };
+                unsafe { ptr::drop_in_place(as_mut_ref) };
+                unsafe { dealloc(event.cast().as_ptr(), Layout::for_value(event.as_ref())) };
             }
-        }
+        
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

@qti3e
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 